### PR TITLE
fix data_pro.py when process amazon 2018 datasets

### DIFF
--- a/pro_data/data_pro.py
+++ b/pro_data/data_pro.py
@@ -195,10 +195,13 @@ if __name__ == '__main__':
             if str(js['asin']) == 'unknown':
                 print("unkown item id")
                 continue
-            reviews.append(js['reviewText'])
-            users_id.append(str(js['reviewerID']))
-            items_id.append(str(js['asin']))
-            ratings.append(str(js['overall']))
+            try:
+                reviews.append(js['reviewText'])
+                users_id.append(str(js['reviewerID']))
+                items_id.append(str(js['asin']))
+                ratings.append(str(js['overall']))
+            except:
+                continue
 
     data_frame = {'user_id': pd.Series(users_id), 'item_id': pd.Series(items_id),
                   'ratings': pd.Series(ratings), 'reviews': pd.Series(reviews)}
@@ -396,7 +399,7 @@ if __name__ == '__main__':
             text2index = []
             wordTokens = text.strip().split()
             if len(wordTokens) == 0:
-                wordTokens = ['unk']
+                wordTokens = ['<unk>']
             text2index = [word_index[w] for w in wordTokens]
             if len(text2index) < maxSentLen:
                 text2index = text2index + [0] * (maxSentLen - len(text2index))
@@ -428,7 +431,7 @@ if __name__ == '__main__':
             text2index = []
             wordTokens = text.strip().split()
             if len(wordTokens) == 0:
-                wordTokens = ['unk']
+                wordTokens = ['<unk>']
             text2index = [word_index[w] for w in wordTokens]
             if len(text2index) < maxSentLen:
                 text2index = text2index + [0] * (maxSentLen - len(text2index))


### PR DESCRIPTION
amazon 2018 datasets 的 *_5.json中
會有一些類似
```
{"image": ["https://images-na.ssl-images-amazon.com/images/I/61ifu-JvzQL._SY88.jpg"], "overall": 5.0, "verified": true, "reviewTime": "04 7, 2018", "reviewerID": "A1CKPC88NHMYGR", "asin": "B001IKJOLW", "style": {"Size:": " 11 B(M) US", "Color:": " Wolf Grey/Black-pink Blast/White"}, "reviewerName": "Cynthia Foyer", "summary": "Five Stars", "unixReviewTime": 1523059200}
```
的資料，導致parsing reviewText出現keyerror的錯誤

並改掉了
```
word_index['<unk>'] = 0
```
與
```
if len(wordTokens) == 0:
    wordTokens = ['unk']
```
兩個unk tokens之間不一致的錯誤